### PR TITLE
feat(package.json): add main entry point to package

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "email": "helloworld@indigotree.co.uk",
     "url": "https://indigotree.co.uk"
   },
+  "main": "dist/main.js",
   "devDependencies": {
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.4",


### PR DESCRIPTION
This should allow users to import from the package without specifying the source file, e.g. instead of doing this
```
import 'netlify-cms-yoast-seo/dist/main.js';
```
you can do this
```
import 'netlify-cms-yoast-seo';
```
which should add the YOAST to window object