### PR TITLE
feat(exports): export YOAST instead of adding to window

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import App from './App'
 import './main.css'
 
-window.YOAST = new App();
+const YOAST = new App();
+export default YOAST;


### PR DESCRIPTION
I think it's better to export the variable instead of adding it to window as a global, for example to avoid name conflicts, only importing it where you need it etc.

This will allow the users to import the YOAST object like this
```
import YOAST from 'netlify-cms-yoast-seo/dist/main.js';
```
Instead of doing this
```
import 'netlify-cms-yoast-seo/dist/main.js';
```